### PR TITLE
Add email to commit message for easier matching

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ var p = lineReader('users.txt', function(line) {
                         reject(err);
                       }
                       console.log("  git commit: " + email);
-                      repo.commit("dummy commit",
+                      repo.commit("dummy commit by" + email,
                         {
                           author: "Dummy <" + email + ">"
                         },


### PR DESCRIPTION
I ran this project and found it very useful, thank you! But there was nothing that clearly connected the username and the email address (for 60+ emails I had used in one run). I had to match the commit hash numbers in `git log` to the same in the GitHub history.
Adding the email to the commit message means I can just see the usernames and emails right next to each other in the GitHub history. 
Thanks again.
